### PR TITLE
refactor: 무한스크롤 hook 불필요한 코드 제거

### DIFF
--- a/queries/useInfiniteScrollQuery.ts
+++ b/queries/useInfiniteScrollQuery.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
@@ -14,14 +12,12 @@ export default function useInfiniteScrollQuery(queryOptions: {
 
   const { ref, inView } = useInView();
 
-  const { isLoading, data, isPending, isError, fetchNextPage, isFetchingNextPage, refetch } = useInfiniteQuery({
+  const { data, isPending, isError, fetchNextPage, isFetchingNextPage, refetch } = useInfiniteQuery({
     queryKey,
     queryFn: ({ pageParam }) => queryFn(pageParam),
     initialPageParam: 0,
     getNextPageParam: (lastPage, allPages, lastPageParam: number) =>
       lastPage.data.hasMore ? lastPageParam + 1 : undefined,
-    gcTime: 0,
-    staleTime: 0,
   });
 
   useEffect(() => {
@@ -30,5 +26,5 @@ export default function useInfiniteScrollQuery(queryOptions: {
     }
   }, [inView, fetchNextPage]);
 
-  return { data, isPending, isError, isFetchingNextPage, ref, refetch, isLoading, fetchNextPage };
+  return { data, isPending, isError, fetchNextPage, isFetchingNextPage, ref, refetch };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #154 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 데이터 `fecthing`에 `useClient`가 필요없어서 지웠습니다.
- `gcTime`, `staleTime` 저번에 버그 수정하다가 지웠었는데, 다시 지웠습니다.
- `isLoading`,`isPending` 겹쳐서 isLoading 지웠습니다.

